### PR TITLE
Update index.html to define character set

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>XKCD Cipher</title>
     <link rel="stylesheet" href="style.css">
+    <meta charset="UTF-8">
 </head>
 <body>
     <h1>XKCD 3054: Scream Cipher</h1>


### PR DESCRIPTION
default Safari setting on MacOS doesn't render the characters properly without the character set defined